### PR TITLE
Revert "Add-authentication"

### DIFF
--- a/myapp/tests/test_views.py
+++ b/myapp/tests/test_views.py
@@ -1,47 +1,16 @@
 from datetime import date
 
 import pytest
-from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from myapp.models import Autor, Libro
 
-User = get_user_model()
-
 
 @pytest.fixture
 def api_client():
     return APIClient()
-
-
-@pytest.fixture
-def user_data():
-    return {
-        "username": "testuser",
-        "password": "testpass123",
-        "email": "test@example.com",
-    }
-
-
-@pytest.fixture
-def user(user_data):
-    return User.objects.create_user(**user_data)
-
-
-@pytest.fixture
-def authenticated_api_client(api_client, user):
-    # Obtener token JWT
-    url = reverse("token_obtain_pair")
-    response = api_client.post(
-        url,
-        {"username": user.username, "password": "testpass123"},
-        format="json",
-    )
-    token = response.data["access"]
-    api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
-    return api_client
 
 
 @pytest.fixture
@@ -72,145 +41,84 @@ def autor(autor_data):
 
 @pytest.fixture
 def libro(libro_data, autor):
-    libro = Libro.objects.create(**libro_data)
-    libro.autores.add(autor)
+    libro = Libro.objects.new(**libro_data)
+    libro.autores.append(autor)
     libro.save()
     return libro
 
 
 @pytest.mark.django_db
 class TestAutorViewSet:
-    def test_list_autores_unauthenticated(self, api_client, autor):
+    def test_list_autores(self, api_client, autor):
         url = reverse("autor-list")
         response = api_client.get(url)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_list_autores(self, authenticated_api_client, autor):
-        url = reverse("autor-list")
-        response = authenticated_api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
 
-    def test_create_autor_unauthenticated(self, api_client, autor_data):
+    def test_create_autor(self, api_client, autor_data):
         url = reverse("autor-list")
         response = api_client.post(url, autor_data, format="json")
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_create_autor(self, authenticated_api_client, autor_data):
-        url = reverse("autor-list")
-        response = authenticated_api_client.post(url, autor_data, format="json")
         assert response.status_code == status.HTTP_201_CREATED
         assert Autor.objects.count() == 1
 
-    def test_retrieve_autor_unauthenticated(self, api_client, autor_data):
+    def test_retrieve_autor(self, api_client, autor_data):
         autor = Autor.objects.create(**autor_data)
         url = reverse("autor-detail", args=[autor.id])
         response = api_client.get(url)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_retrieve_autor(self, authenticated_api_client, autor_data):
-        autor = Autor.objects.create(**autor_data)
-        url = reverse("autor-detail", args=[autor.id])
-        response = authenticated_api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
         assert response.data["nombre"] == autor_data["nombre"]
 
-    def test_update_autor_unauthenticated(self, api_client, autor_data):
+    def test_update_autor(self, api_client, autor_data):
         autor = Autor.objects.create(**autor_data)
         url = reverse("autor-detail", args=[autor.id])
         updated_data = autor_data.copy()
         updated_data["nombre"] = "Gabriel José"
         response = api_client.put(url, updated_data, format="json")
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_update_autor(self, authenticated_api_client, autor_data):
-        autor = Autor.objects.create(**autor_data)
-        url = reverse("autor-detail", args=[autor.id])
-        updated_data = autor_data.copy()
-        updated_data["nombre"] = "Gabriel José"
-        response = authenticated_api_client.put(url, updated_data, format="json")
         assert response.status_code == status.HTTP_200_OK
         assert response.data["nombre"] == "Gabriel José"
 
-    def test_delete_autor_unauthenticated(self, api_client, autor_data):
+    def test_delete_autor(self, api_client, autor_data):
         autor = Autor.objects.create(**autor_data)
         url = reverse("autor-detail", args=[autor.id])
         response = api_client.delete(url)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_delete_autor(self, authenticated_api_client, autor_data):
-        autor = Autor.objects.create(**autor_data)
-        url = reverse("autor-detail", args=[autor.id])
-        response = authenticated_api_client.delete(url)
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert Autor.objects.count() == 0
 
 
 @pytest.mark.django_db
 class TestLibroViewSet:
-    def test_list_libros_unauthenticated(self, api_client, libro_data):
+    def test_list_libros(self, api_client, libro_data):
         Libro.objects.create(**libro_data)
         url = reverse("libro-list")
         response = api_client.get(url)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_list_libros(self, authenticated_api_client, libro_data):
-        Libro.objects.create(**libro_data)
-        url = reverse("libro-list")
-        response = authenticated_api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
 
-    def test_create_libro_unauthenticated(self, api_client, libro_data):
+    def test_create_libro(self, api_client, libro_data):
         url = reverse("libro-list")
         response = api_client.post(url, libro_data, format="json")
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_create_libro(self, authenticated_api_client, libro_data):
-        url = reverse("libro-list")
-        response = authenticated_api_client.post(url, libro_data, format="json")
         assert response.status_code == status.HTTP_201_CREATED
         assert Libro.objects.count() == 1
 
-    def test_retrieve_libro_unauthenticated(self, api_client, libro_data):
+    def test_retrieve_libro(self, api_client, libro_data):
         libro = Libro.objects.create(**libro_data)
         url = reverse("libro-detail", args=[libro.id])
         response = api_client.get(url)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_retrieve_libro(self, authenticated_api_client, libro_data):
-        libro = Libro.objects.create(**libro_data)
-        url = reverse("libro-detail", args=[libro.id])
-        response = authenticated_api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
         assert response.data["titulo"] == libro_data["titulo"]
 
-    def test_update_libro_unauthenticated(self, api_client, libro_data):
+    def test_update_libro(self, api_client, libro_data):
         libro = Libro.objects.create(**libro_data)
         url = reverse("libro-detail", args=[libro.id])
         updated_data = libro_data.copy()
         updated_data["titulo"] = "El amor en los tiempos del cólera"
         response = api_client.put(url, updated_data, format="json")
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_update_libro(self, authenticated_api_client, libro_data):
-        libro = Libro.objects.create(**libro_data)
-        url = reverse("libro-detail", args=[libro.id])
-        updated_data = libro_data.copy()
-        updated_data["titulo"] = "El amor en los tiempos del cólera"
-        response = authenticated_api_client.put(url, updated_data, format="json")
         assert response.status_code == status.HTTP_200_OK
         assert response.data["titulo"] == "El amor en los tiempos del cólera"
 
-    def test_delete_libro_unauthenticated(self, api_client, libro_data):
+    def test_delete_libro(self, api_client, libro_data):
         libro = Libro.objects.create(**libro_data)
         url = reverse("libro-detail", args=[libro.id])
         response = api_client.delete(url)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_delete_libro(self, authenticated_api_client, libro_data):
-        libro = Libro.objects.create(**libro_data)
-        url = reverse("libro-detail", args=[libro.id])
-        response = authenticated_api_client.delete(url)
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert Libro.objects.count() == 0

--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -49,7 +49,6 @@ INSTALLED_APPS = [
     "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
     "rest_framework",
-    "rest_framework_simplejwt",
     "myapp.apps.MyappConfig",
 ]
 
@@ -153,21 +152,3 @@ if (
     # Enable the WhiteNoise storage backend, which compresses static files to reduce disk use
     # and renames the files with unique names for each version to support long-term caching
     STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
-
-# REST Framework settings
-REST_FRAMEWORK = {
-    "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework_simplejwt.authentication.JWTAuthentication",
-    ),
-    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
-}
-
-# JWT settings
-from datetime import timedelta
-
-SIMPLE_JWT = {
-    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=60),
-    "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
-    "ALGORITHM": "HS256",
-    "SIGNING_KEY": SECRET_KEY,
-}

--- a/myproject/urls.py
+++ b/myproject/urls.py
@@ -17,16 +17,8 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import include, path
-from rest_framework_simplejwt.views import (
-    TokenObtainPairView,
-    TokenRefreshView,
-    TokenVerifyView,
-)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("myapp.urls")),
-    path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
-    path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
-    path("api/token/verify/", TokenVerifyView.as_view(), name="token_verify"),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ asgiref==3.8.1
 click==8.1.8
 Django==5.2
 djangorestframework==3.16.0
-djangorestframework-simplejwt==5.3.1
 exceptiongroup==1.2.2
 gunicorn==23.0.0
 h11==0.14.0


### PR DESCRIPTION
Quitamos la autenticación sobre los endpoints para mantener la simplicidad de la aplicación

Reverts rarce/django-drf-cicd-example#3